### PR TITLE
await all of the setup commands properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,9 +160,7 @@ function messageCreateHandler(message) {
 }
 
 async function asyncmain() {
-    config.commands.map(async (e) => {
-        await setupCommand(e);
-    });
+    await Promise.all(config.commands.map(setupCommand));
 
     // const duration = nextWednesday() - new Date();
     // console.log(`waiting ${duration}ms`);


### PR DESCRIPTION
previously, this wouldn't actually block execution, since the `await` was inside the map callback